### PR TITLE
Add hxmath library to Build Options

### DIFF
--- a/lixSetup/haxe_libraries/hxmath.hxml
+++ b/lixSetup/haxe_libraries/hxmath.hxml
@@ -1,0 +1,3 @@
+# @install: lix --silent download "haxelib:/hxmath#0.18.0" into hxmath/0.18.0/haxelib
+-cp ${HAXE_LIBCACHE}/hxmath/0.18.0/haxelib/src
+-D hxmath=0.18.0

--- a/src/Libs.hx
+++ b/src/Libs.hx
@@ -19,6 +19,7 @@ class Libs {
 				name: "hxColorToolkit",
 				help: "https://github.com/andyli/hxColorToolkit"
 			},
+			{name: "hxmath", help: "https://github.com/tbrosman/hxmath", args: []},
 			{name: "nape", help: "https://github.com/deltaluca/nape"},
 			{name: "pecan", help: "https://github.com/Aurel300/pecan"},
 			{name: "pixijs", head: ["<script src='../../../lib/js/pixi.min.js'></script>"]},
@@ -39,6 +40,7 @@ class Libs {
 				name: "hxColorToolkit",
 				help: "https://github.com/andyli/hxColorToolkit"
 			},
+			{name: "hxmath", help: "https://github.com/tbrosman/hxmath", args: []},
 			{name: "pecan", help: "https://github.com/Aurel300/pecan"},
 			{name: "thx.core", help: "https://github.com/fponticelli/thx.core"},
 			{name: "thx.culture", help: "https://github.com/fponticelli/thx.culture"},
@@ -56,6 +58,7 @@ class Libs {
 				name: "hxColorToolkit",
 				help: "https://github.com/andyli/hxColorToolkit"
 			},
+			{name: "hxmath", help: "https://github.com/tbrosman/hxmath", args: []},
 			{name: "pecan", help: "https://github.com/Aurel300/pecan"},
 			{name: "thx.core", help: "https://github.com/fponticelli/thx.core"},
 			{name: "thx.culture", help: "https://github.com/fponticelli/thx.culture"},
@@ -73,6 +76,7 @@ class Libs {
 				name: "hxColorToolkit",
 				help: "https://github.com/andyli/hxColorToolkit"
 			},
+			{name: "hxmath", help: "https://github.com/tbrosman/hxmath", args: []},
 			{name: "pecan", help: "https://github.com/Aurel300/pecan"},
 			{name: "safety", help: "https://github.com/RealyUniqueName/Safety"},
 			{name: "thx.core", help: "https://github.com/fponticelli/thx.core"},


### PR DESCRIPTION
This PR adds the [hxmath library](https://github.com/tbrosman/hxmath) to the available build options.